### PR TITLE
feat: add console logs tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,30 @@ Uploads a file using a file input element.
 }
 ```
 
+### get_console_logs
+Returns browser console log entries.
+
+**Parameters:**
+- `sinceMs` (optional): Only return entries newer than now - sinceMs
+  - Type: number
+- `level` (optional): Minimum log level
+  - Type: string
+  - Enum: ["ALL", "SEVERE", "WARNING", "INFO", "DEBUG"]
+- `max` (optional): Maximum number of entries to return
+  - Type: number
+
+**Example:**
+```json
+{
+  "tool": "get_console_logs",
+  "parameters": {
+    "sinceMs": 3000,
+    "level": "ALL",
+    "max": 200
+  }
+}
+```
+
 ### take_screenshot
 Captures a screenshot of the current page.
 


### PR DESCRIPTION
## Summary
- enable browser logging when starting driver
- add get_console_logs tool to fetch browser console logs
- document usage of get_console_logs

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run lint` (fails: Missing script: "lint")

------
https://chatgpt.com/codex/tasks/task_e_68996f5cad38832ebe549a06da027c81